### PR TITLE
Updated to latest SDK and proxy support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,9 @@
     <packaging>jar</packaging>
     <name>Amazon DynamoDB Session Manager for Tomcat</name>
     <version>1.0.2</version>
-    <description>The Amazon DynamoDB Session Manager for Tomcat provides a custom session manager for Tomcat 7 that stores session data in Amazon DynamoDB, Amazon's fully managed NoSQL database service.</description>
+    <description>The Amazon DynamoDB Session Manager for Tomcat provides a custom session manager for Tomcat 7 that
+        stores session data in Amazon DynamoDB, Amazon's fully managed NoSQL database service.
+    </description>
     <url>https://aws.amazon.com/java</url>
 
     <scm>
@@ -34,145 +36,133 @@
     </developers>
 
     <dependencies>
-    	<dependency>
-    		<groupId>com.amazonaws</groupId>
-    		<artifactId>aws-java-sdk</artifactId>
-    		<version>1.9.0</version>
-    	</dependency>
-    	<dependency>
-    		<groupId>org.apache.tomcat</groupId>
-    		<artifactId>tomcat-catalina</artifactId>
-    		<version>7.0.42</version>
-    	</dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-dynamodb</artifactId>
+            <version>1.9.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-catalina</artifactId>
+            <version>7.0.42</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>
-      <resources>
-	<resource>
-	  <directory>${basedir}</directory>
-	  <includes>
-	    <include>LICENSE.txt</include>
-	    <include>NOTICE.txt</include>
-	    <include>README.txt</include>
-	  </includes>
-	</resource>
-      </resources>
+        <resources>
+            <resource>
+                <directory>${basedir}</directory>
+                <includes>
+                    <include>LICENSE.txt</include>
+                    <include>NOTICE.txt</include>
+                    <include>README.txt</include>
+                </includes>
+            </resource>
+        </resources>
 
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-	  <version>2.3</version>
-          <configuration>
-            <source>1.5</source>
-            <target>1.5</target>
-            <encoding>UTF-8</encoding>
-          </configuration>
-        </plugin>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                    <encoding>UTF-8</encoding>
+                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                </configuration>
+            </plugin>
 
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-shade-plugin</artifactId>
-          <version>2.2</version>
-          <executions>
-            <execution>
-	      <phase>package</phase>
-	      <goals>
-		<goal>shade</goal>
-	      </goals>
-	      <configuration>
-		<minimizeJar>true</minimizeJar>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <minimizeJar>true</minimizeJar>
 
-		<relocations>
-		  <relocation>
-		    <pattern>com.amazonaws</pattern>
-		    <shadedPattern>com.amazonaws.tomcatsessionmanager.amazonaws</shadedPattern>
-		    <excludes>
-                      <!-- Don't shade this class, since we reference it by name in Tomcat configuration -->
-		      <exclude>com.amazonaws.services.dynamodb.sessionmanager.DynamoDBSessionManager</exclude>
-		    </excludes>
-		  </relocation>
-		  <relocation>
-		    <pattern>org.apache.http</pattern>
-		    <shadedPattern>com.amazonaws.tomcatsessionmanager.apache.http</shadedPattern>
-		  </relocation>
-		  <relocation>
-		    <pattern>org.apache.commons.logging</pattern>
-		    <shadedPattern>com.amazonaws.tomcatsessionmanager.apache.commons.logging</shadedPattern>
-		  </relocation>
-		  <relocation>
-		    <pattern>org.apache.commons.codec</pattern>
-		    <shadedPattern>com.amazonaws.tomcatsessionmanager.apache.commons.codec</shadedPattern>
-		  </relocation>
-                  <!-- TODO: This needs to be updated to the new Jackson version when we update to a later SDK version -->
-		  <relocation>
-		    <pattern>org.codehaus</pattern>
-		    <shadedPattern>com.amazonaws.tomcatsessionmanager.codehaus</shadedPattern>
-		  </relocation>
-		</relocations>
-		
-		<artifactSet>
-                  <includes>
-		    <include>com.amazonaws:aws-java-sdk</include>
-		    <include>commons-logging:*</include>
-		    <include>org.apache.httpcomponents:*</include>
-		    <include>commons-codec:*</include>
-		    <include>org.codehaus.jackson:*</include>
-                  </includes>
-		</artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com</pattern>
+                                    <shadedPattern>com.amazonaws.tomcatsessionmanager</shadedPattern>
+                                    <excludes>
+                                        <!-- Don't shade this class, since we reference it by name in Tomcat configuration -->
+                                        <exclude>com.amazonaws.services.dynamodb.sessionmanager.DynamoDBSessionManager</exclude>
+                                    </excludes>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org</pattern>
+                                    <shadedPattern>com.amazonaws.tomcatsessionmanager</shadedPattern>
+                                </relocation>
+                            </relocations>
 
-		<filters>
-                  <filter>
-		    <!-- Pull in everything from commons-logging, so that we pick up all the adapter
-			 implementations that may not be statically referenced, but could be needed. -->
-                    <artifact>commons-logging:commons-logging</artifact>
-                    <includes>
-                      <include>**</include>
-                    </includes>
-                  </filter>
-		</filters>
+                            <filters>
+                                <filter>
+                                    <!-- Pull in everything from commons-logging, so that we pick up all the adapter
+                                     implementations that may not be statically referenced, but could be needed. -->
+                                    <artifact>commons-logging:commons-logging</artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                </filter>
+                                <filter>
+                                    <!-- Exclude all hidden files from all artifacts.
+                                     such as .gitkeep from aws-java-sdk-s3 -->
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>.*</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
 
-	      </configuration>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
     </build>
 
     <profiles>
-      <profile>
-	<id>publishing</id>
-	
-	<build>
-	  <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-gpg-plugin</artifactId>
-              <executions>
-		<execution>
-		  <id>sign-artifacts</id>
-		  <phase>verify</phase>
-		  <goals>
-                    <goal>sign</goal>
-		  </goals>
-		</execution>
-              </executions>
-            </plugin>
+        <profile>
+            <id>publishing</id>
 
-	    <plugin>
-	      <groupId>org.sonatype.plugins</groupId>
-	      <artifactId>nexus-staging-maven-plugin</artifactId>
-	      <version>1.5.1</version>
-	      <extensions>true</extensions>
-	      <configuration>
-		<serverId>sonatype-nexus-staging</serverId>
-		<nexusUrl>https://oss.sonatype.org</nexusUrl>
-                <releaseAfterClose>true</releaseAfterClose>
-	      </configuration>
-	    </plugin>
-	  </plugins>
-	</build>
-      </profile>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.5.1</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>sonatype-nexus-staging</serverId>
+                            <nexusUrl>https://oss.sonatype.org</nexusUrl>
+                            <releaseAfterClose>true</releaseAfterClose>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -89,18 +89,37 @@
 
                             <relocations>
                                 <relocation>
-                                    <pattern>com</pattern>
-                                    <shadedPattern>com.amazonaws.tomcatsessionmanager</shadedPattern>
+                                    <pattern>com.amazonaws</pattern>
+                                    <shadedPattern>com.amazonaws.tomcatsessionmanager.amazonaws</shadedPattern>
                                     <excludes>
                                         <!-- Don't shade this class, since we reference it by name in Tomcat configuration -->
                                         <exclude>com.amazonaws.services.dynamodb.sessionmanager.DynamoDBSessionManager</exclude>
                                     </excludes>
                                 </relocation>
                                 <relocation>
-                                    <pattern>org</pattern>
-                                    <shadedPattern>com.amazonaws.tomcatsessionmanager</shadedPattern>
+                                    <pattern>com.fasterxml</pattern>
+                                    <shadedPattern>com.amazonaws.tomcatsessionmanager.fasterxml</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>com.amazonaws.tomcatsessionmanager.apache.commons</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.http</pattern>
+                                    <shadedPattern>com.amazonaws.tomcatsessionmanager.apache.http</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.joda</pattern>
+                                    <shadedPattern>com.amazonaws.tomcatsessionmanager.joda</shadedPattern>
                                 </relocation>
                             </relocations>
+
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                                    <!-- Prevent .gitkeep from aws-java-sdk-s3 to be included -->
+                                    <resource>.gitkeep</resource>
+                                </transformer>
+                            </transformers>
 
                             <filters>
                                 <filter>
@@ -111,15 +130,18 @@
                                         <include>**</include>
                                     </includes>
                                 </filter>
-                                <filter>
-                                    <!-- Exclude all hidden files from all artifacts.
-                                     such as .gitkeep from aws-java-sdk-s3 -->
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>.*</exclude>
-                                    </excludes>
-                                </filter>
                             </filters>
+
+                            <artifactSet>
+                                <includes>
+                                    <include>com.amazonaws:*</include>
+                                    <include>commons-logging:*</include>
+                                    <include>org.apache.httpcomponents:*</include>
+                                    <include>commons-codec:*</include>
+                                    <include>com.fasterxml.jackson.core:*</include>
+                                    <include>joda-time:*</include>
+                                </includes>
+                            </artifactSet>
 
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     	<dependency>
     		<groupId>com.amazonaws</groupId>
     		<artifactId>aws-java-sdk</artifactId>
-    		<version>1.5.4</version>
+    		<version>1.9.0</version>
     	</dependency>
     	<dependency>
     		<groupId>org.apache.tomcat</groupId>


### PR DESCRIPTION
The project, I'm working on at work, must support proxy.
So I forked the project to add support for proxy first.

Afterwords, I noticed the project depends on an old version of the SDK that may not properly support proxy on ClientConfiguration.
Therefore, I updated to the latest SDK (1.9.0, released on October 8th 2014).
Which implies to update the pom.xml for the shade plugin.