### PR TITLE
MaxInactiveInterval is changed at a milli second.

### DIFF
--- a/src/main/java/com/amazonaws/services/dynamodb/sessionmanager/DynamoDBSessionManager.java
+++ b/src/main/java/com/amazonaws/services/dynamodb/sessionmanager/DynamoDBSessionManager.java
@@ -143,7 +143,7 @@ public class DynamoDBSessionManager extends PersistentManagerBase {
         dynamoSessionStore.setDynamoClient(dynamo);
         dynamoSessionStore.setSessionTableName(this.tableName);
 
-        expiredSessionReaper = new ExpiredSessionReaper(dynamo, tableName, this.maxInactiveInterval);
+        expiredSessionReaper = new ExpiredSessionReaper(dynamo, tableName, (this.maxInactiveInterval * 1000));
     }
 
     @Override


### PR DESCRIPTION
The value set as MaxInactiveInterval is session-config > session-timeout from web.xml or default settings(2 hours).

session-timeout settings : minutes
library settings : seconds (60 * 60 * 2)

The conversion is not carried out although a milli second is used in calculation of a deletion term.
(It recognize second)

Thanks.