### PR TITLE
update aws-java-sdk version and fix shade plugin issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,10 @@
 		    <pattern>com.fasterxml</pattern>
 		    <shadedPattern>com.amazonaws.tomcatsessionmanager.fasterxml</shadedPattern>
 		  </relocation>
+		  <relocation>
+		  	<pattern>org.joda.time</pattern>
+		  	<shadedPattern>com.amazonaws.tomcatsessionmanager.joda.time</shadedPattern>
+		  </relocation>
 		</relocations>
 		
 		<artifactSet>
@@ -118,6 +122,7 @@
 				    <include>org.apache.httpcomponents:*</include>
 				    <include>commons-codec:*</include>
 				    <include>com.fasterxml.jackson.core:*</include>
+				    <include>joda-time:*</include>
                   </includes>
 		</artifactSet>
 
@@ -126,6 +131,14 @@
 		    <!-- Pull in everything from commons-logging, so that we pick up all the adapter
 			 implementations that may not be statically referenced, but could be needed. -->
                     <artifact>commons-logging:commons-logging</artifact>
+                    <includes>
+                      <include>**</include>
+                    </includes>
+                  </filter>
+                   <filter>
+		    <!-- Pull in everything from commons-logging, so that we pick up all the adapter
+			 implementations that may not be statically referenced, but could be needed. -->
+                    <artifact>>com.fasterxml.jackson.core:*</artifact>
                     <includes>
                       <include>**</include>
                     </includes>

--- a/pom.xml
+++ b/pom.xml
@@ -37,12 +37,13 @@
     	<dependency>
     		<groupId>com.amazonaws</groupId>
     		<artifactId>aws-java-sdk</artifactId>
-    		<version>1.5.4</version>
+    		<version>1.9.8</version>
     	</dependency>
     	<dependency>
     		<groupId>org.apache.tomcat</groupId>
     		<artifactId>tomcat-catalina</artifactId>
     		<version>7.0.42</version>
+		<scope>provided</scope>
     	</dependency>
     </dependencies>
 
@@ -113,7 +114,7 @@
 		
 		<artifactSet>
                   <includes>
-		    <include>com.amazonaws:aws-java-sdk</include>
+		    <include>com.amazonaws:aws-java-sdk*</include>
 		    <include>commons-logging:*</include>
 		    <include>org.apache.httpcomponents:*</include>
 		    <include>commons-codec:*</include>

--- a/pom.xml
+++ b/pom.xml
@@ -105,20 +105,19 @@
 		    <pattern>org.apache.commons.codec</pattern>
 		    <shadedPattern>com.amazonaws.tomcatsessionmanager.apache.commons.codec</shadedPattern>
 		  </relocation>
-                  <!-- TODO: This needs to be updated to the new Jackson version when we update to a later SDK version -->
 		  <relocation>
-		    <pattern>org.codehaus</pattern>
-		    <shadedPattern>com.amazonaws.tomcatsessionmanager.codehaus</shadedPattern>
+		    <pattern>com.fasterxml</pattern>
+		    <shadedPattern>com.amazonaws.tomcatsessionmanager.fasterxml</shadedPattern>
 		  </relocation>
 		</relocations>
 		
 		<artifactSet>
                   <includes>
-		    <include>com.amazonaws:aws-java-sdk*</include>
-		    <include>commons-logging:*</include>
-		    <include>org.apache.httpcomponents:*</include>
-		    <include>commons-codec:*</include>
-		    <include>org.codehaus.jackson:*</include>
+				    <include>com.amazonaws:aws-java-sdk*</include>
+				    <include>commons-logging:*</include>
+				    <include>org.apache.httpcomponents:*</include>
+				    <include>commons-codec:*</include>
+				    <include>com.fasterxml.jackson.core:*</include>
                   </includes>
 		</artifactSet>
 

--- a/pom.xml
+++ b/pom.xml
@@ -135,14 +135,6 @@
                       <include>**</include>
                     </includes>
                   </filter>
-                   <filter>
-		    <!-- Pull in everything from commons-logging, so that we pick up all the adapter
-			 implementations that may not be statically referenced, but could be needed. -->
-                    <artifact>>com.fasterxml.jackson.core:*</artifact>
-                    <includes>
-                      <include>**</include>
-                    </includes>
-                  </filter>
 		</filters>
 
 	      </configuration>

--- a/src/main/java/com/amazonaws/services/dynamodb/sessionmanager/DynamoDBSessionStore.java
+++ b/src/main/java/com/amazonaws/services/dynamodb/sessionmanager/DynamoDBSessionStore.java
@@ -68,7 +68,6 @@ public class DynamoDBSessionStore extends StoreBase {
     }
 
 
-    @Override
     public void clear() throws IOException {
         final Set<String> keysCopy = new HashSet<String>();
         keysCopy.addAll(keys);
@@ -85,7 +84,6 @@ public class DynamoDBSessionStore extends StoreBase {
         keys.clear();
     }
 
-    @Override
     public int getSize() throws IOException {
         // The item count from describeTable is updated every ~6 hours
         TableDescription table = dynamo.describeTable(new DescribeTableRequest().withTableName(sessionTableName)).getTable();
@@ -94,12 +92,10 @@ public class DynamoDBSessionStore extends StoreBase {
         return (int)itemCount;
     }
 
-    @Override
     public String[] keys() throws IOException {
         return keys.toArray(new String[0]);
     }
 
-    @Override
     public Session load(String id) throws ClassNotFoundException, IOException {
         Map<String, AttributeValue> item = DynamoUtils.loadItemBySessionId(dynamo, sessionTableName, id);
         if (item == null || !item.containsKey(SessionTableAttributes.SESSION_ID_KEY) || !item.containsKey(SessionTableAttributes.SESSION_DATA_ATTRIBUTE)) {
@@ -143,13 +139,11 @@ public class DynamoDBSessionStore extends StoreBase {
         return session;
     }
 
-    @Override
     public void save(Session session) throws IOException {
         DynamoUtils.storeSession(dynamo, sessionTableName, session);
         keys.add(session.getId());
     }
 
-    @Override
     public void remove(String id) throws IOException {
         DynamoUtils.deleteSession(dynamo, sessionTableName, id);
         keys.remove(id);

--- a/src/main/java/com/amazonaws/services/dynamodb/sessionmanager/ExpiredSessionReaper.java
+++ b/src/main/java/com/amazonaws/services/dynamodb/sessionmanager/ExpiredSessionReaper.java
@@ -73,7 +73,6 @@ public class ExpiredSessionReaper {
      * ThreadFactory for creating the daemon reaper thread.
      */
     private final class ExpiredSessionReaperThreadFactory implements ThreadFactory {
-        @Override
         public Thread newThread(Runnable runnable) {
             Thread thread = new Thread(runnable);
             thread.setDaemon(true);
@@ -86,7 +85,6 @@ public class ExpiredSessionReaper {
      * Runnable that is invoked periodically to scan for expired sessions.
      */
     private class ExpiredSessionReaperRunnable implements Runnable {
-        @Override
         public void run() {
             reapExpiredSessions();
         }


### PR DESCRIPTION
The current release doesn't work with eu-central-1 region so an update to the java-sdk is required. This requires an update to the shade plugin configuration (also fixing an issue where aws code wasn't included).